### PR TITLE
Adds the option to disable the x-content-type-options header 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,8 @@ Options
    `X-Download-Options <https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj542450(v=vs.85)?redirectedfrom=MSDN>`_
    header to ``noopen`` to prevent IE >= 8 to from opening file downloads
    directly and only save them instead.
+-  ``x_content_type_options``, default ``True``, Protects against MIME sniffing vulnerabilities.
+-  ``x_xss_protection``, default ``True``, Protects against cross-site scripting (XSS) attacks.
 
 Per-view options
 ~~~~~~~~~~~~~~~~

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -87,7 +87,9 @@ class Talisman(object):
             content_security_policy_nonce_in=None,
             referrer_policy=DEFAULT_REFERRER_POLICY,
             session_cookie_secure=True,
-            session_cookie_http_only=True):
+            session_cookie_http_only=True,
+            x_content_type_options=True,
+            x_xss_protection=True):
         """
         Initialization.
 
@@ -131,6 +133,9 @@ class Talisman(object):
                 session cookie.
             force_file_save: Prevents the user from opening a file download
                 directly on >= IE 8
+            x_content_type_options: Prevents MIME type sniffing
+            x_xss_protection: Prevents the page from loading when the browser
+                detects reflected cross-site scripting attacks
 
         See README.rst for a detailed description of each option.
         """
@@ -191,6 +196,10 @@ class Talisman(object):
             app.config['SESSION_COOKIE_HTTPONLY'] = True
 
         self.force_file_save = force_file_save
+
+        self.x_content_type_options = x_content_type_options
+
+        self.x_xss_protection = x_xss_protection
 
         self.app = app
 
@@ -348,8 +357,11 @@ class Talisman(object):
                 options['frame_options_allow_from'])
 
     def _set_content_security_policy_headers(self, headers, options):
-        headers['X-XSS-Protection'] = '1; mode=block'
-        headers['X-Content-Type-Options'] = 'nosniff'
+        if self.x_xss_protection:
+            headers['X-XSS-Protection'] = '1; mode=block'
+
+        if self.x_content_type_options:
+            headers['X-Content-Type-Options'] = 'nosniff'
 
         if self.force_file_save:
             headers['X-Download-Options'] = 'noopen'

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -170,6 +170,18 @@ class TestTalismanExtension(unittest.TestCase):
             response.headers['Content-Security-Policy']
         )
 
+        # x-content-type-options disabled
+        app = flask.Flask(__name__)
+        Talisman(app, x_content_type_options=False)
+        response = app.test_client().get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertNotIn('X-Content-Type-Options', response.headers)
+
+        # x-xss-protection disabled
+        app = flask.Flask(__name__)
+        Talisman(app, x_xss_protection=False)
+        response = app.test_client().get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertNotIn('X-XSS-Protection', response.headers)
+
     def testContentSecurityPolicyOptionsReport(self):
         # report-only policy
         self.talisman.content_security_policy_report_only = True


### PR DESCRIPTION
Originally from https://github.com/GoogleCloudPlatform/flask-talisman/pull/75.