### PR TITLE
Release v0.8.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ long_description = open('README.rst', 'r', encoding='utf-8').read()
 setup(
     name='flask-talisman',
 
-    version='0.7.0',
+    version='0.8.0',
 
     description='HTTP security headers for Flask.',
     long_description=long_description,


### PR DESCRIPTION
Once #7 is done, we can release v0.8.0. Release should be done by adding a new release in Github; you can add this changelog to the release notes. Alternatively, give me a :+1: and I'll make the release once you approved of the PR.

# v0.8.0

## Changes
- `object-src` is now a default CSP directive with value `'none'`. @QEDK (#2)
- `Document Policy` and `Permissions Policy` are now supported. @tunetheweb (#3)
- The ingest cohort directive for Permissions Policy is by default turned off (#3)
- You can now disable the `X-Content-Type-Options` and `X-XSS-Protection` headers. By default they're turned on. @ezelbanaan (#4)
- You can now specify SameSite attributes for session cookies; by default that's set to `Lax`. @tylersalminen #5 
- You can now customize nonce configuration per view / route. @tunetheweb (#6) 
- The length of the CSP nonce is now properly limited. @tunetheweb
- Removed the legacy `X-Content-Security-Policy` header and its associated option, `legacy_content_security_policy_header`.

## For maintainers
- Moved CI / CD to Github Actions from Travis (#1)
- Removed Python 3.4 from CI (#1)
- Increased line length to 120 (#1)