### PR TITLE
Deprecate Python 2.x support

### DIFF
--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -14,7 +14,6 @@
 from collections import OrderedDict
 
 import flask
-from six import iteritems, string_types
 
 
 DENY = 'DENY'
@@ -293,7 +292,7 @@ class Talisman(object):
             return policy
 
         policies = []
-        for section, content in iteritems(policy):
+        for section, content in policy.items():
             policy_part = '{}={}'.format(section, content)
 
             policies.append(policy_part)
@@ -304,7 +303,7 @@ class Talisman(object):
 
     def _parse_policy(self, policy):
         local_options = self._get_local_options()
-        if isinstance(policy, string_types):
+        if isinstance(policy, str):
             # parse the string into a policy dict
             policy_string = policy
             policy = OrderedDict()
@@ -314,8 +313,8 @@ class Talisman(object):
                 policy[policy_parts[0]] = " ".join(policy_parts[1:])
 
         policies = []
-        for section, content in iteritems(policy):
-            if not isinstance(content, string_types):
+        for section, content in policy.items():
+            if not isinstance(content, str):
                 content = ' '.join(content)
             policy_part = '{} {}'.format(section, content)
 

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -18,7 +18,6 @@ import unittest
 
 import flask
 from flask_talisman import ALLOW_FROM, DENY, NONCE_LENGTH, Talisman
-from six import iteritems
 
 
 HTTPS_ENVIRON = {'wsgi.url_scheme': 'https'}
@@ -57,7 +56,7 @@ class TestTalismanExtension(unittest.TestCase):
             'Referrer-Policy': 'strict-origin-when-cross-origin'
         }
 
-        for key, value in iteritems(headers):
+        for key, value in headers.items():
             self.assertEqual(response.headers.get(key), value)
 
         csp = response.headers.get('Content-Security-Policy')

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ def lint(session):
     session.run('flake8', '--import-order-style=google', 'flask_talisman')
 
 
-@nox.session(python=['2.7', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9'])
+@nox.session(python=['3.4', '3.5', '3.6', '3.7', '3.8', '3.9'])
 def tests(session):
     """Run the test suite"""
     session.install('flask', 'mock', 'pytest', 'pytest-cov')

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,7 @@ setup(
         'License :: OSI Approved :: Apache Software License',
 
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -61,5 +59,5 @@ setup(
 
     packages=['flask_talisman'],
 
-    install_requires=['six>=1.9.0'],
+    install_requires=[],
 )


### PR DESCRIPTION
Since Python 2.x is EOL, deprecating support for it ensures we're not running Talisman on top of Python versions without proper security patching. Furthermore, we can package Talisman dependency free 🎉 

Probably needs:
- [ ] Major version bump