### PR TITLE
Remove obsolete Permissions Policy directive interest-cohort

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,6 @@ The default configuration:
 -  Sets a strict `Referrer-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>`_
    of ``strict-origin-when-cross-origin`` that governs which referrer information should be included with
    requests made.
--  Disables interest-cohort by default in the `Permissions-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy>`_
-   like `Drupal <https://www.drupal.org/project/drupal/issues/3209628>`_ to enhance privacy protection.
 
 
 In addition to Talisman, you **should always use a cross-site request
@@ -116,7 +114,7 @@ Options
 
 -  ``feature_policy``, default ``{}``, see the `Feature Policy`_ section (`about Feature Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy>`_).
 
--  ``permissions_policy``, default ``{'interest-cohort': '()'}``, see the `Permissions Policy`_ section (`about Permissions Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy>`_).
+-  ``permissions_policy``, default ``{}``, see the `Permissions Policy`_ section (`about Permissions Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy>`_).
 -  ``document_policy``, default ``{}``, see the `Document Policy`_ section (`about Document Policy <https://wicg.github.io/document-policy/>`_).
 
 -  ``session_cookie_secure``, default ``True``, set the session cookie
@@ -376,9 +374,6 @@ the Permission Policy setting will take precedence in browsers that support both
 
 It should be noted that the syntax differs between Feature Policy and Permission Policy
 as can be seen from the ``geolocation`` examples provided.
-
-The default Permissions Policy is ``interest-cohort=()``, which opts sites out of
-`Federated Learning of Cohorts <https://wicg.github.io/floc/>`_ an interest-based advertising initiative.
 
 Permission Policy can be set either using a dictionary, or using a string.
 

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -46,7 +46,6 @@ GOOGLE_CSP_POLICY = {
 }
 
 DEFAULT_PERMISSIONS_POLICY = {
-    'interest-cohort': '()'
 }
 
 DEFAULT_DOCUMENT_POLICY = {

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -293,11 +293,6 @@ class TestTalismanExtension(unittest.TestCase):
         self.assertIn('vibrate \'none\'', response.headers['Feature-Policy'])
 
     def testPermissionsPolicy(self):
-        # default disabled FLoC
-        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        permissions_policy = response.headers['Permissions-Policy']
-        self.assertIn('interest-cohort=()', permissions_policy)
-
         self.talisman.permissions_policy['geolocation'] = '()'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         permissions_policy = response.headers['Permissions-Policy']


### PR DESCRIPTION
This PR resolves the following warning in the console of Chromium-based browsers:
![image](https://user-images.githubusercontent.com/45960703/158007355-b4040310-60a3-4f4b-bfea-5d488bc75cc1.png)

Permission Policy directive `interest-cohort` is non-standard and existed only in Google Chrome from version 89 to 92 ([removed in 93](https://bugs.chromium.org/p/chromium/issues/detail?id=1230149#c5)). As per [official documentation](https://github.com/jkarlin/topics#:~:text=FLoC%20ended%20its%20experiment%20in%20July%20of%202021.), "FLoC ended its experiment in July of 2021". Since July of 2021, the server-side component returns empty data, effectively disabling FLoC even in Chrome versions which supported it. No other major browser ever implemented or enabled FLoC.

This PR simply removes `interest-cohort` directive altogether since it is no longer needed.

This is an alternative to #20: only one of these two should be merged.