### PR TITLE
Add Permissions Policy directive browsing-topics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ The default configuration:
 -  Sets a strict `Referrer-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>`_
    of ``strict-origin-when-cross-origin`` that governs which referrer information should be included with
    requests made.
+-  Disables ``browsing-topics`` by default in the `Permissions-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy>`_
+   like `Drupal <https://www.drupal.org/project/drupal/issues/3209628>`_ to enhance privacy protection.
 
 
 In addition to Talisman, you **should always use a cross-site request
@@ -110,7 +112,7 @@ Options
 
 -  ``feature_policy``, default ``{}``, see the `Feature Policy`_ section (`about Feature Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy>`_).
 
--  ``permissions_policy``, default ``{}``, see the `Permissions Policy`_ section (`about Permissions Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy>`_).
+-  ``permissions_policy``, default ``{'browsing-topics': '()'}``, see the `Permissions Policy`_ section (`about Permissions Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy>`_).
 -  ``document_policy``, default ``{}``, see the `Document Policy`_ section (`about Document Policy <https://wicg.github.io/document-policy/>`_).
 
 -  ``session_cookie_secure``, default ``True``, set the session cookie
@@ -370,6 +372,10 @@ the Permission Policy setting will take precedence in browsers that support both
 
 It should be noted that the syntax differs between Feature Policy and Permission Policy
 as can be seen from the ``geolocation`` examples provided.
+
+The default Permissions Policy is ``browsing-topics=()``, which opts sites out of
+`Federated Learning of Cohorts <https://wicg.github.io/floc/>`_ an interest-based advertising initiative
+called Topics API.
 
 Permission Policy can be set either using a dictionary, or using a string.
 

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -46,6 +46,8 @@ GOOGLE_CSP_POLICY = {
 }
 
 DEFAULT_PERMISSIONS_POLICY = {
+    # Disable Topics API
+    'browsing-topics': '()'
 }
 
 DEFAULT_DOCUMENT_POLICY = {

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -303,12 +303,14 @@ class TestTalismanExtension(unittest.TestCase):
         self.talisman.permissions_policy['geolocation'] = '()'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         permissions_policy = response.headers['Permissions-Policy']
+        self.assertIn('browsing-topics=()', permissions_policy)
         self.assertIn('geolocation=()', permissions_policy)
 
         self.talisman.permissions_policy['geolocation'] = '()'
         self.talisman.permissions_policy['fullscreen'] = '(self, "https://example.com")'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         permissions_policy = response.headers['Permissions-Policy']
+        self.assertIn('browsing-topics=()', permissions_policy)
         self.assertIn('geolocation=(), fullscreen=(self, "https://example.com")', permissions_policy)
 
         # no policy


### PR DESCRIPTION
This PR adds Permissions Policy directive `browsing-topics` which controls access to [The Topics API](https://developer.chrome.com/docs/privacy-sandbox/topics/). This API is Chromium-only and is still in Origin Trial (in Chrome 101 to 104 until [August 29](https://developer.chrome.com/origintrials/#/view_trial/771241436187197441)) and it might land in Chrome 105 which is scheduled to be released on August 30.

Fixes #22.
Related to #20 and #21.