### PR TITLE
fix typo in permissions_policy examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -384,18 +384,18 @@ Disable access to Geolocation interface and Microphone using dictionary syntax
 
 .. code:: python
 
-    permission_policy = {
+    permissions_policy = {
         'geolocation': '()',
         'microphone': '()'
     }
-    talisman = Talisman(app, permission_policy=permission_policy)
+    talisman = Talisman(app, permissions_policy=permissions_policy)
 
 Disable access to Geolocation interface and Microphone using string syntax
 
 .. code:: python
 
-    permission_policy = 'geolocation=(), microphone=()'
-    talisman = Talisman(app, permission_policy=permission_policy)
+    permissions_policy = 'geolocation=(), microphone=()'
+    talisman = Talisman(app, permissions_policy=permissions_policy)
 
 Document Policy
 ---------------


### PR DESCRIPTION
Found a small typo in the documentation this morning that breaks app initialization with an unexpected kwarg error. Just need to swap `permission_policy` for `permissions_policy`. 