### PR TITLE
Add minimum Python version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+exclude flask_talisman/talisman_test.py

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections import OrderedDict
-
 import flask
 
 
@@ -143,20 +141,9 @@ class Talisman(object):
 
         See README.rst for a detailed description of each option.
         """
-        if isinstance(feature_policy, dict):
-            self.feature_policy = OrderedDict(feature_policy)
-        else:
-            self.feature_policy = feature_policy
-
-        if isinstance(permissions_policy, dict):
-            self.permissions_policy = OrderedDict(permissions_policy)
-        else:
-            self.permissions_policy = permissions_policy
-
-        if isinstance(document_policy, dict):
-            self.document_policy = OrderedDict(document_policy)
-        else:
-            self.document_policy = document_policy
+        self.feature_policy = feature_policy
+        self.permissions_policy = permissions_policy
+        self.document_policy = document_policy
 
         self.force_https = force_https
         self.force_https_permanent = force_https_permanent
@@ -172,10 +159,7 @@ class Talisman(object):
         self.strict_transport_security_include_subdomains = \
             strict_transport_security_include_subdomains
 
-        if isinstance(content_security_policy, dict):
-            self.content_security_policy = OrderedDict(content_security_policy)
-        else:
-            self.content_security_policy = content_security_policy
+        self.content_security_policy = content_security_policy
         self.content_security_policy_report_uri = \
             content_security_policy_report_uri
         self.content_security_policy_report_only = \
@@ -307,7 +291,7 @@ class Talisman(object):
         if isinstance(policy, str):
             # parse the string into a policy dict
             policy_string = policy
-            policy = OrderedDict()
+            policy = {}
 
             for policy_part in policy_string.split(';'):
                 policy_parts = policy_part.strip().split(' ')

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,11 @@ setup(
 
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
 
         'Operating System :: POSIX',
         'Operating System :: MacOS',
@@ -60,4 +60,5 @@ setup(
     packages=['flask_talisman'],
 
     install_requires=[],
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
I am not completely sure if dropping Python version support is worth it or if 3.7 is the correct minimum.
#28 changed the minimum tested Python version to 3.7.
Getting rid of `collections.OrderedDict` cleans up the code.
As mentioned, Python 3.6 is End-Of-Life since 2021-12-23. (Python 3.7 is EOL since 2023-06-27)